### PR TITLE
Fix: Convert linked image URLs to relative paths

### DIFF
--- a/src/logic/file-downloader.ts
+++ b/src/logic/file-downloader.ts
@@ -201,9 +201,15 @@ export async function downloadMarkdownWithImages(
     // マークダウン内の画像URLを相対パスに置換
     let processedMarkdown = markdown;
     imageMap.forEach((relativePath, originalUrl) => {
+      const escapedUrl = originalUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      
       // ![alt](url) 形式を置換
-      const imageRegex = new RegExp(`!\\[([^\\]]*)\\]\\(${originalUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\)`, 'g');
+      const imageRegex = new RegExp(`!\\[([^\\]]*)\\]\\(${escapedUrl}\\)`, 'g');
       processedMarkdown = processedMarkdown.replace(imageRegex, `![$1](${relativePath})`);
+      
+      // [![alt](url)](link_url) 形式のリンクURLも置換（画像が同じURLにリンクしている場合）
+      const linkedImageRegex = new RegExp(`\\[!\\[([^\\]]*)\\]\\([^)]+\\)\\]\\(${escapedUrl}\\)`, 'g');
+      processedMarkdown = processedMarkdown.replace(linkedImageRegex, `[![$1](${relativePath})](${relativePath})`);
     });
     
     // マークダウンファイルをダウンロード


### PR DESCRIPTION
Fixes #2

Adds support for converting linked image URLs to relative paths. Previously, only simple image references were converted, but linked images (`[![alt](url)](link_url)`) kept their external URLs.

**Changes:**
- Added regex pattern to handle `[![alt](url)](link_url)` format
- Convert external link URLs to relative paths when they match downloaded images
- Maintains existing functionality for simple image references

Generated with [Claude Code](https://claude.ai/code)